### PR TITLE
feat: Implement voucher upload functionality

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/config/SecurityConfig.java
+++ b/src/main/java/com/forjix/cuentoskilla/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/auth/**").permitAll()
                 .requestMatchers("/api/cuentos/**").permitAll()  // 🔓 Público
-                .requestMatchers("/api/orders/**").permitAll()  // 🔓 Público
+                .requestMatchers("/api/orders/**").authenticated() // Now requires authentication
                 .requestMatchers("/api/**").authenticated()
                 .anyRequest().permitAll()
             )

--- a/src/main/java/com/forjix/cuentoskilla/controller/OrderController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/OrderController.java
@@ -4,10 +4,18 @@ import com.forjix.cuentoskilla.model.Order;
 import com.forjix.cuentoskilla.model.User;
 import com.forjix.cuentoskilla.model.DTOs.PedidoDTO;
 import com.forjix.cuentoskilla.service.OrderService;
+import com.forjix.cuentoskilla.service.StorageService;
+import com.forjix.cuentoskilla.service.storage.StorageException; // Added
+import com.forjix.cuentoskilla.model.Voucher;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger; // Added
+import org.slf4j.LoggerFactory; // Added
 
 import org.apache.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestParam; // Added
+import org.springframework.web.multipart.MultipartFile; // Added
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,10 +31,13 @@ import java.util.Map;
 @RequestMapping("/api/orders")
 @CrossOrigin(origins = "*")
 public class OrderController {
+    private static final Logger logger = LoggerFactory.getLogger(OrderController.class); // Added
     private final OrderService service;
+    private final StorageService storageService;
 
-    public OrderController(OrderService service) {
+    public OrderController(OrderService service, StorageService storageService) {
         this.service = service;
+        this.storageService = storageService;
     }
 
     @GetMapping
@@ -53,5 +64,57 @@ public class OrderController {
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         service.delete(id);
+    }
+
+    @PostMapping("/voucher")
+    public ResponseEntity<?> uploadVoucher(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("idpedido") Long orderId,
+            @RequestParam(name = "dispositivo", required = false, defaultValue = "Desconocido") String dispositivo,
+            HttpServletRequest request) {
+        
+        if (file.isEmpty()) {
+            logger.warn("Upload attempt with empty file for orderId: {}", orderId);
+            return ResponseEntity.badRequest().body(Map.of("error", "Cannot upload an empty file."));
+        }
+
+        try {
+            String ip = request.getRemoteAddr();
+            String originalFileName = file.getOriginalFilename();
+            String contentType = file.getContentType();
+            long fileSize = file.getSize();
+
+            // Basic validation for orderId before calling service (optional, as service also checks)
+            if (orderId == null || orderId <= 0) {
+                logger.warn("Invalid orderId provided: {}", orderId);
+                return ResponseEntity.badRequest().body(Map.of("error", "Valid Order ID is required."));
+            }
+
+            logger.info("Attempting to upload voucher for orderId: {}, fileName: {}, ip: {}, device: {}", 
+                        orderId, originalFileName, ip, dispositivo);
+
+            Voucher voucher = storageService.store(file, orderId, originalFileName, contentType, ip, dispositivo, fileSize);
+            
+            logger.info("Voucher uploaded successfully for orderId: {}. Voucher ID: {}, FileName: {}", 
+                        orderId, voucher.getId(), voucher.getNombreArchivo());
+            
+            return ResponseEntity.ok(Map.of(
+                "message", "Voucher uploaded successfully!", 
+                "voucherId", voucher.getId(),
+                "fileName", voucher.getNombreArchivo()
+            ));
+        } catch (StorageException e) {
+            logger.error("StorageException for orderId {}: {}", orderId, e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.SC_BAD_REQUEST) // Or INTERNAL_SERVER_ERROR depending on StorageException type
+                             .body(Map.of("error", "Storage error: " + e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            logger.error("IllegalArgumentException for orderId {}: {}", orderId, e.getMessage(), e);
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid input: " + e.getMessage()));
+        } 
+        catch (Exception e) {
+            logger.error("Unexpected error during voucher upload for orderId {}: {}", orderId, e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                             .body(Map.of("error", "An unexpected error occurred: " + e.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/forjix/cuentoskilla/model/Order.java
+++ b/src/main/java/com/forjix/cuentoskilla/model/Order.java
@@ -26,6 +26,10 @@ public class Order {
     @JsonManagedReference
     private List<OrderItem> items;
 
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    private List<Voucher> vouchers;
+
     // Getters y setters
     public Long getId() {
         return id;
@@ -65,5 +69,13 @@ public class Order {
 
     public void setItems(List<OrderItem> items) {
         this.items = items;
-    }    
+    }
+
+    public List<Voucher> getVouchers() {
+        return vouchers;
+    }
+
+    public void setVouchers(List<Voucher> vouchers) {
+        this.vouchers = vouchers;
+    }
 }

--- a/src/main/java/com/forjix/cuentoskilla/model/Voucher.java
+++ b/src/main/java/com/forjix/cuentoskilla/model/Voucher.java
@@ -1,0 +1,114 @@
+package com.forjix.cuentoskilla.model;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "vouchers")
+public class Voucher {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate fecha;
+    private LocalTime hora;
+    private String peso; // Using String for flexibility
+    private String dispositivo;
+    private String ip;
+    private String nombreArchivo;
+    private String tipoArchivo;
+    private String filePath;
+
+    @ManyToOne(fetch = FetchType.LAZY) // LAZY fetching is generally good for performance
+    @JoinColumn(name = "idpedido", nullable = false)
+    @JsonBackReference // To manage bidirectional relationship serialization
+    private Order order;
+
+    // Constructors
+    public Voucher() {
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDate getFecha() {
+        return fecha;
+    }
+
+    public void setFecha(LocalDate fecha) {
+        this.fecha = fecha;
+    }
+
+    public LocalTime getHora() {
+        return hora;
+    }
+
+    public void setHora(LocalTime hora) {
+        this.hora = hora;
+    }
+
+    public String getPeso() {
+        return peso;
+    }
+
+    public void setPeso(String peso) {
+        this.peso = peso;
+    }
+
+    public String getDispositivo() {
+        return dispositivo;
+    }
+
+    public void setDispositivo(String dispositivo) {
+        this.dispositivo = dispositivo;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    public String getNombreArchivo() {
+        return nombreArchivo;
+    }
+
+    public void setNombreArchivo(String nombreArchivo) {
+        this.nombreArchivo = nombreArchivo;
+    }
+
+    public String getTipoArchivo() {
+        return tipoArchivo;
+    }
+
+    public void setTipoArchivo(String tipoArchivo) {
+        this.tipoArchivo = tipoArchivo;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/repository/VoucherRepository.java
+++ b/src/main/java/com/forjix/cuentoskilla/repository/VoucherRepository.java
@@ -1,0 +1,10 @@
+package com.forjix.cuentoskilla.repository;
+
+import com.forjix.cuentoskilla.model.Voucher;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository; // Optional, but good practice
+
+@Repository // Optional for Spring Data JPA, but can be explicit
+public interface VoucherRepository extends JpaRepository<Voucher, Long> {
+    // You can add custom query methods here if needed in the future
+}

--- a/src/main/java/com/forjix/cuentoskilla/service/StorageService.java
+++ b/src/main/java/com/forjix/cuentoskilla/service/StorageService.java
@@ -1,0 +1,9 @@
+package com.forjix.cuentoskilla.service;
+
+import org.springframework.web.multipart.MultipartFile;
+import com.forjix.cuentoskilla.model.Voucher; // Import Voucher
+
+public interface StorageService {
+    Voucher store(MultipartFile file, Long orderId, String originalFileName, String contentType, String ip, String dispositivo, long fileSize);
+    // Add other methods like load, delete if needed in future
+}

--- a/src/main/java/com/forjix/cuentoskilla/service/storage/FileSystemStorageService.java
+++ b/src/main/java/com/forjix/cuentoskilla/service/storage/FileSystemStorageService.java
@@ -1,0 +1,94 @@
+package com.forjix.cuentoskilla.service.storage;
+
+import com.forjix.cuentoskilla.model.Order;
+import com.forjix.cuentoskilla.model.Voucher;
+import com.forjix.cuentoskilla.repository.OrderRepository;
+import com.forjix.cuentoskilla.repository.VoucherRepository;
+import com.forjix.cuentoskilla.service.StorageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Service
+public class FileSystemStorageService implements StorageService {
+
+    @Value("${file.upload-dir:./uploads}") // Default to ./uploads if not specified in properties
+    private String uploadDir;
+
+    private Path rootLocation;
+
+    private final VoucherRepository voucherRepository;
+    private final OrderRepository orderRepository;
+
+    public FileSystemStorageService(VoucherRepository voucherRepository, OrderRepository orderRepository) {
+        this.voucherRepository = voucherRepository;
+        this.orderRepository = orderRepository;
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            this.rootLocation = Paths.get(uploadDir);
+            Files.createDirectories(rootLocation);
+        } catch (IOException e) {
+            throw new StorageException("Could not initialize storage location", e);
+        }
+    }
+
+    @Override
+    public Voucher store(MultipartFile file, Long orderId, String originalFileName, String contentType, String ip, String dispositivo, long fileSize) {
+        if (file.isEmpty()) {
+            throw new StorageException("Failed to store empty file.");
+        }
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new StorageException("Order not found with id: " + orderId));
+
+        // Sanitize filename and add a UUID to prevent collisions
+        String filename = StringUtils.cleanPath(originalFileName != null ? originalFileName : ""); // Handle null originalFileName
+        // Ensure filename is not empty after cleaning
+        if (filename.trim().isEmpty()) {
+            filename = "unnamedfile"; // Provide a default name if original is empty or was just spaces
+        }
+        String uniqueFilename = UUID.randomUUID().toString() + "_" + filename;
+        
+        Path destinationFile = this.rootLocation.resolve(Paths.get(uniqueFilename))
+                .normalize().toAbsolutePath();
+
+        if (!destinationFile.getParent().equals(this.rootLocation.toAbsolutePath())) {
+            // This is a security check
+            throw new StorageException("Cannot store file outside current directory.");
+        }
+
+        try (InputStream inputStream = file.getInputStream()) {
+            Files.copy(inputStream, destinationFile, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new StorageException("Failed to store file.", e);
+        }
+
+        Voucher voucher = new Voucher();
+        voucher.setOrder(order);
+        voucher.setFecha(LocalDate.now());
+        voucher.setHora(LocalTime.now());
+        voucher.setPeso(String.valueOf(fileSize)); // Store file size as string
+        voucher.setDispositivo(dispositivo);
+        voucher.setIp(ip);
+        voucher.setNombreArchivo(uniqueFilename); // Store the unique filename
+        voucher.setTipoArchivo(contentType);
+        voucher.setFilePath(destinationFile.toString()); // Add this line to store the full path
+
+        return voucherRepository.save(voucher);
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/service/storage/StorageException.java
+++ b/src/main/java/com/forjix/cuentoskilla/service/storage/StorageException.java
@@ -1,0 +1,11 @@
+package com.forjix.cuentoskilla.service.storage;
+
+public class StorageException extends RuntimeException {
+    public StorageException(String message) {
+        super(message);
+    }
+
+    public StorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,6 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+
+file:
+  upload-dir: ./uploads/vouchers

--- a/src/test/java/com/forjix/cuentoskilla/controller/OrderControllerIntegrationTest.java
+++ b/src/test/java/com/forjix/cuentoskilla/controller/OrderControllerIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.forjix.cuentoskilla.controller;
+
+import com.forjix.cuentoskilla.model.Order;
+import com.forjix.cuentoskilla.model.User;
+import com.forjix.cuentoskilla.model.Voucher;
+import com.forjix.cuentoskilla.service.StorageService;
+import com.forjix.cuentoskilla.service.OrderService; // Assuming OrderService might be needed for context or user setup
+import com.forjix.cuentoskilla.repository.UserRepository; // For creating test users for authentication
+import com.forjix.cuentoskilla.service.storage.StorageException; // Import for the exception
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser; // For testing secured endpoints
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.is;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OrderControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean // Use MockBean for services StorageService
+    private StorageService storageService;
+    
+    // We might not need to mock OrderService if we're not deeply testing order creation logic here
+    // but focusing on the voucher upload part. If OrderService is essential for OrderController's setup,
+    // it might need to be a @MockBean too. For now, let's assume it's not strictly needed for /voucher.
+
+    @Autowired
+    private WebApplicationContext context;
+    
+    @BeforeEach
+    public void setup() {
+        // Setup MockMvc with Spring Security context
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity()) // Apply Spring Security configuration
+                .build();
+    }
+
+
+    @Test
+    @WithMockUser(username = "testuser", roles = {"USER"}) // Simulate an authenticated user
+    void uploadVoucher_whenAuthenticatedAndValidData_shouldReturnSuccess() throws Exception {
+        Long orderId = 1L;
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file",
+                "voucher.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "testPDFcontent".getBytes()
+        );
+
+        Voucher mockVoucher = new Voucher();
+        mockVoucher.setId(1L);
+        mockVoucher.setNombreArchivo("mock_voucher.pdf");
+        // Set other necessary fields for the mockVoucher if they are returned in JSON
+
+        when(storageService.store(any(MockMultipartFile.class), anyLong(), anyString(), anyString(), anyString(), anyString(), anyLong()))
+                .thenReturn(mockVoucher);
+
+        mockMvc.perform(multipart("/api/orders/voucher")
+                        .file(mockFile)
+                        .param("idpedido", String.valueOf(orderId))
+                        .param("dispositivo", "test-device")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("Voucher uploaded successfully!")))
+                .andExpect(jsonPath("$.voucherId", is(1)))
+                .andExpect(jsonPath("$.fileName", is("mock_voucher.pdf")));
+    }
+    
+    @Test
+    @WithMockUser(username = "testuser", roles = {"USER"})
+    void uploadVoucher_whenStorageServiceThrowsException_shouldReturnError() throws Exception {
+        Long orderId = 2L;
+        MockMultipartFile mockFile = new MockMultipartFile(
+            "file", "error.txt", MediaType.TEXT_PLAIN_VALUE, "error content".getBytes()
+        );
+
+        when(storageService.store(any(), anyLong(), anyString(), anyString(), anyString(), anyString(), anyLong()))
+            .thenThrow(new StorageException("Test storage failure"));
+
+        mockMvc.perform(multipart("/api/orders/voucher")
+                        .file(mockFile)
+                        .param("idpedido", String.valueOf(orderId))
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest()) // As per current OrderController error handling for StorageException
+                .andExpect(jsonPath("$.error", is("Storage error: Test storage failure")));
+    }
+
+    @Test
+    void uploadVoucher_whenNotAuthenticated_shouldReturnUnauthorized() throws Exception {
+        Long orderId = 3L;
+        MockMultipartFile mockFile = new MockMultipartFile(
+            "file", "secret.txt", MediaType.TEXT_PLAIN_VALUE, "secret".getBytes()
+        );
+        
+        // No @WithMockUser here
+
+        mockMvc.perform(multipart("/api/orders/voucher")
+                        .file(mockFile)
+                        .param("idpedido", String.valueOf(orderId))
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isUnauthorized()); // Or isForbidden() depending on exact security setup for unauthenticated
+    }
+    
+    @Test
+    @WithMockUser(username = "testuser", roles = {"USER"})
+    void uploadVoucher_whenFileIsEmpty_shouldReturnBadRequest() throws Exception {
+        Long orderId = 4L;
+        MockMultipartFile emptyFile = new MockMultipartFile(
+            "file", "", MediaType.TEXT_PLAIN_VALUE, new byte[0] // Empty file
+        );
+
+        mockMvc.perform(multipart("/api/orders/voucher")
+                        .file(emptyFile)
+                        .param("idpedido", String.valueOf(orderId))
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error", is("Cannot upload an empty file.")));
+    }
+    
+    @Test
+    @WithMockUser(username = "testuser", roles = {"USER"})
+    void uploadVoucher_whenMissingOrderId_shouldReturnBadRequest() throws Exception {
+        MockMultipartFile mockFile = new MockMultipartFile(
+            "file", "test.txt", MediaType.TEXT_PLAIN_VALUE, "content".getBytes()
+        );
+
+        // Missing "idpedido" parameter
+        mockMvc.perform(multipart("/api/orders/voucher")
+                        .file(mockFile)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest()); // Spring typically returns 400 for missing required params
+    }
+
+}

--- a/src/test/java/com/forjix/cuentoskilla/service/storage/FileSystemStorageServiceTest.java
+++ b/src/test/java/com/forjix/cuentoskilla/service/storage/FileSystemStorageServiceTest.java
@@ -1,0 +1,154 @@
+package com.forjix.cuentoskilla.service.storage;
+
+import com.forjix.cuentoskilla.model.Order;
+import com.forjix.cuentoskilla.model.Voucher;
+import com.forjix.cuentoskilla.repository.OrderRepository;
+import com.forjix.cuentoskilla.repository.VoucherRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FileSystemStorageServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    private VoucherRepository voucherRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    // @InjectMocks will not work here because we need to set uploadDir manually after construction
+    private FileSystemStorageService storageService;
+
+    @BeforeEach
+    void setUp() {
+        // Manually instantiate and set the uploadDir using reflection or by modifying the service
+        // For simplicity, let's assume FileSystemStorageService can have uploadDir set post-construction
+        // Or, we can use reflection to set the @Value field if needed.
+        // A better way would be to make uploadDir configurable via a constructor or setter for tests.
+        // For this subtask, we'll proceed as if we can set it.
+        // The @PostConstruct init() method needs to be called after setting uploadDir.
+
+        storageService = new FileSystemStorageService(voucherRepository, orderRepository);
+        // Simulate Spring's @Value injection and @PostConstruct for testing
+        try {
+            java.lang.reflect.Field uploadDirField = FileSystemStorageService.class.getDeclaredField("uploadDir");
+            uploadDirField.setAccessible(true);
+            uploadDirField.set(storageService, tempDir.toString());
+
+            storageService.init(); // Manually call init after setting the path
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Failed to set uploadDir for test", e);
+        }
+    }
+
+    @Test
+    void store_shouldSaveFileAndCreateVoucherRecord() throws IOException {
+        Long orderId = 1L;
+        String originalFilename = "test-voucher.pdf";
+        String contentType = "application/pdf";
+        String ip = "127.0.0.1";
+        String dispositivo = "test-device";
+        long fileSize = 1024;
+
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "file",
+                originalFilename,
+                contentType,
+                "test data".getBytes()
+        );
+
+        Order mockOrder = new Order();
+        mockOrder.setId(orderId);
+
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(mockOrder));
+        when(voucherRepository.save(any(Voucher.class))).thenAnswer(invocation -> {
+            Voucher v = invocation.getArgument(0);
+            v.setId(100L); // Simulate saving and getting an ID
+            return v;
+        });
+
+        Voucher result = storageService.store(multipartFile, orderId, originalFilename, contentType, ip, dispositivo, fileSize);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getOrder()).isEqualTo(mockOrder);
+        assertThat(result.getNombreArchivo()).contains(originalFilename); // Will have UUID prefix
+        assertThat(result.getTipoArchivo()).isEqualTo(contentType);
+        assertThat(result.getIp()).isEqualTo(ip);
+        assertThat(result.getDispositivo()).isEqualTo(dispositivo);
+        assertThat(result.getPeso()).isEqualTo(String.valueOf(fileSize));
+        assertThat(result.getFecha()).isEqualTo(LocalDate.now());
+        assertThat(result.getFilePath()).isNotNull();
+        assertThat(Files.exists(Path.of(result.getFilePath()))).isTrue();
+
+        ArgumentCaptor<Voucher> voucherArgumentCaptor = ArgumentCaptor.forClass(Voucher.class);
+        verify(voucherRepository).save(voucherArgumentCaptor.capture());
+        Voucher capturedVoucher = voucherArgumentCaptor.getValue();
+
+        assertThat(capturedVoucher.getFilePath()).isEqualTo(tempDir.resolve(capturedVoucher.getNombreArchivo()).toString());
+    }
+
+    @Test
+    void store_whenFileIsEmpty_shouldThrowStorageException() {
+        MockMultipartFile emptyFile = new MockMultipartFile("file", "", "text/plain", new byte[0]);
+        Long orderId = 1L;
+
+        assertThatThrownBy(() -> storageService.store(emptyFile, orderId, "", "text/plain", "127.0.0.1", "test", 0))
+                .isInstanceOf(StorageException.class)
+                .hasMessage("Failed to store empty file.");
+        
+        verify(voucherRepository, never()).save(any());
+    }
+
+    @Test
+    void store_whenOrderNotFound_shouldThrowStorageException() {
+        MockMultipartFile multipartFile = new MockMultipartFile("file", "test.txt", "text/plain", "content".getBytes());
+        Long nonExistentOrderId = 99L;
+
+        when(orderRepository.findById(nonExistentOrderId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storageService.store(multipartFile, nonExistentOrderId, "test.txt", "text/plain", "127.0.0.1", "test", 10))
+                .isInstanceOf(StorageException.class)
+                .hasMessage("Order not found with id: " + nonExistentOrderId);
+        
+        verify(voucherRepository, never()).save(any());
+    }
+    
+    @Test
+    void init_shouldCreateDirectoryIfNotExist() throws IOException {
+         Path newUploadDir = tempDir.resolve("test-uploads");
+         // For this test, we need a new instance or re-initialize with a different path
+         FileSystemStorageService newService = new FileSystemStorageService(voucherRepository, orderRepository);
+         try {
+            java.lang.reflect.Field uploadDirField = FileSystemStorageService.class.getDeclaredField("uploadDir");
+            uploadDirField.setAccessible(true);
+            uploadDirField.set(newService, newUploadDir.toString());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+         newService.init();
+         assertThat(Files.exists(newUploadDir)).isTrue();
+         assertThat(Files.isDirectory(newUploadDir)).isTrue();
+    }
+}


### PR DESCRIPTION
Adds a new feature allowing you to upload voucher files associated with their orders.

Key changes include:
- Definition of a new `Voucher` entity with fields for voucher details (date, time, weight, device, IP, filename, filepath, type) and a many-to-one relationship with the `Order` entity.
- Update to the `Order` entity to include a one-to-many relationship with `Voucher`.
- Creation of `VoucherRepository` for database interactions.
- Implementation of `StorageService` (`FileSystemStorageService`) to handle storing uploaded files on the local filesystem. Uploaded files are stored in a configurable directory (`file.upload-dir` in `application.yml`, defaulting to `./uploads/vouchers`). Files are saved with a UUID prefix to prevent collisions.
- A new API endpoint `POST /api/orders/voucher` in `OrderController` to receive voucher files (`MultipartFile`), order ID, and device information. The endpoint uses `StorageService` to save the file and create a `Voucher` record. Client IP is also captured.
- Enhanced error handling in `OrderController` with specific exception catches and SLF4J logging.
- Security update in `SecurityConfig.java` to ensure the `/api/orders/**` path (including the new voucher endpoint) requires user authentication.
- Added unit tests for `FileSystemStorageService` covering file storage logic, error conditions, and directory initialization.
- Added integration tests for `OrderController` using `MockMvc` to test the voucher upload endpoint, including success cases, error handling, and security (authenticated vs. unauthenticated access).