### PR TITLE
Fix order creation timestamp

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/service/OrderService.java
+++ b/src/main/java/com/forjix/cuentoskilla/service/OrderService.java
@@ -128,7 +128,7 @@ public class OrderService {
     public Order save(PedidoDTO pedidoDTO, User authenticatedUser) {
         Order order = new Order();
         order.setUser(authenticatedUser); // Set the authenticated user
-        order.setFecha(LocalDateTime.now());
+        order.setCreatedAt(LocalDateTime.now());
         order.setEstado(OrderStatus.PAGO_PENDIENTE); // New orders are PENDIENTE
 
         List<OrderItem> items = pedidoDTO.getItems().stream().map(dto -> {


### PR DESCRIPTION
## Summary
- use the correct setter when adding the creation date for an order

## Testing
- `./mvnw -ntp -DskipTests package` *(fails: wget failure due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_68653c3b14f08327bcb30f407a4c03d9