### PR TITLE
Implement configuration catalog API

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/config/ConfigCategory.java
+++ b/src/main/java/com/forjix/cuentoskilla/config/ConfigCategory.java
@@ -1,0 +1,56 @@
+package com.forjix.cuentoskilla.config;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "config_category")
+public class ConfigCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id1;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String code;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public Integer getId1() {
+        return id1;
+    }
+
+    public void setId1(Integer id1) {
+        this.id1 = id1;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/config/ConfigItem.java
+++ b/src/main/java/com/forjix/cuentoskilla/config/ConfigItem.java
@@ -1,0 +1,64 @@
+package com.forjix.cuentoskilla.config;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "config_item")
+@IdClass(ConfigItemId.class)
+public class ConfigItem {
+    @Id
+    @Column(name = "id1")
+    private Integer categoryId;
+
+    @Id
+    private Integer id2;
+
+    @Column(nullable = false, length = 200)
+    private String label;
+
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private String data;
+
+    @Column(nullable = false)
+    private Boolean sensitive;
+
+    public Integer getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(Integer categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public Integer getId2() {
+        return id2;
+    }
+
+    public void setId2(Integer id2) {
+        this.id2 = id2;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public Boolean getSensitive() {
+        return sensitive;
+    }
+
+    public void setSensitive(Boolean sensitive) {
+        this.sensitive = sensitive;
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/config/ConfigItemId.java
+++ b/src/main/java/com/forjix/cuentoskilla/config/ConfigItemId.java
@@ -1,0 +1,46 @@
+package com.forjix.cuentoskilla.config;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ConfigItemId implements Serializable {
+    private Integer categoryId;
+    private Integer id2;
+
+    public ConfigItemId() {
+    }
+
+    public ConfigItemId(Integer categoryId, Integer id2) {
+        this.categoryId = categoryId;
+        this.id2 = id2;
+    }
+
+    public Integer getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(Integer categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public Integer getId2() {
+        return id2;
+    }
+
+    public void setId2(Integer id2) {
+        this.id2 = id2;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConfigItemId that = (ConfigItemId) o;
+        return Objects.equals(categoryId, that.categoryId) && Objects.equals(id2, that.id2);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(categoryId, id2);
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/controller/ConfigController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/ConfigController.java
@@ -1,0 +1,95 @@
+package com.forjix.cuentoskilla.controller;
+
+import com.forjix.cuentoskilla.config.ConfigCategory;
+import com.forjix.cuentoskilla.config.ConfigItem;
+import com.forjix.cuentoskilla.config.ConfigItemId;
+import com.forjix.cuentoskilla.repository.ConfigCategoryRepository;
+import com.forjix.cuentoskilla.repository.ConfigItemRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/config")
+@CrossOrigin
+public class ConfigController {
+
+    private final ConfigCategoryRepository categoryRepo;
+    private final ConfigItemRepository itemRepo;
+
+    public ConfigController(ConfigCategoryRepository categoryRepo, ConfigItemRepository itemRepo) {
+        this.categoryRepo = categoryRepo;
+        this.itemRepo = itemRepo;
+    }
+
+    @GetMapping("/category")
+    @PreAuthorize("hasRole('ADMIN')")
+    public List<ConfigCategory> listCategories() {
+        return categoryRepo.findAll();
+    }
+
+    @PostMapping("/category")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> createCategory(@RequestBody ConfigCategory category) {
+        if (categoryRepo.existsByCode(category.getCode())) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", "code already exists"));
+        }
+        ConfigCategory saved = categoryRepo.save(category);
+        return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    @GetMapping("/category/{code}/item")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<ConfigItem>> listItems(@PathVariable String code) {
+        return categoryRepo.findByCode(code)
+                .map(cat -> ResponseEntity.ok(itemRepo.findByCategoryIdOrderById2(cat.getId1())))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/category/{code}/item")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> createItem(@PathVariable String code, @RequestBody ConfigItem item) {
+        return categoryRepo.findByCode(code)
+                .map(cat -> {
+                    item.setCategoryId(cat.getId1());
+                    ConfigItem saved = itemRepo.save(item);
+                    return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/category/{code}/item/{id2}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ConfigItem> updateItem(@PathVariable String code, @PathVariable Integer id2,
+                                                 @RequestBody ConfigItem item) {
+        return categoryRepo.findByCode(code).map(cat -> {
+            ConfigItemId itemId = new ConfigItemId(cat.getId1(), id2);
+            return itemRepo.findById(itemId)
+                    .map(existing -> {
+                        existing.setLabel(item.getLabel());
+                        existing.setData(item.getData());
+                        existing.setSensitive(item.getSensitive());
+                        return ResponseEntity.ok(itemRepo.save(existing));
+                    })
+                    .orElse(ResponseEntity.notFound().build());
+        }).orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/category/{code}/item/{id2}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deleteItem(@PathVariable String code, @PathVariable Integer id2) {
+        return categoryRepo.findByCode(code).map(cat -> {
+            ConfigItemId itemId = new ConfigItemId(cat.getId1(), id2);
+            if (!itemRepo.existsById(itemId)) {
+                return ResponseEntity.notFound().build();
+            }
+            itemRepo.deleteById(itemId);
+            return ResponseEntity.noContent().build();
+        }).orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/repository/ConfigCategoryRepository.java
+++ b/src/main/java/com/forjix/cuentoskilla/repository/ConfigCategoryRepository.java
@@ -1,0 +1,11 @@
+package com.forjix.cuentoskilla.repository;
+
+import com.forjix.cuentoskilla.config.ConfigCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ConfigCategoryRepository extends JpaRepository<ConfigCategory, Integer> {
+    boolean existsByCode(String code);
+    Optional<ConfigCategory> findByCode(String code);
+}

--- a/src/main/java/com/forjix/cuentoskilla/repository/ConfigItemRepository.java
+++ b/src/main/java/com/forjix/cuentoskilla/repository/ConfigItemRepository.java
@@ -1,0 +1,11 @@
+package com.forjix.cuentoskilla.repository;
+
+import com.forjix.cuentoskilla.config.ConfigItem;
+import com.forjix.cuentoskilla.config.ConfigItemId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ConfigItemRepository extends JpaRepository<ConfigItem, ConfigItemId> {
+    List<ConfigItem> findByCategoryIdOrderById2(Integer categoryId);
+}


### PR DESCRIPTION
## Summary
- add `ConfigCategory` and `ConfigItem` entities
- add repositories for new entities
- implement `ConfigController` with admin endpoints for CRUD operations

## Testing
- `./mvnw -q test` *(fails: Maven could not download dependencies due to no Internet)*

------
https://chatgpt.com/codex/tasks/task_e_6866a88daea48327a1fdf6f391250c35