### PR TITLE
Fix deleteItem optional fallback

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/controller/ConfigController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/ConfigController.java
@@ -90,6 +90,6 @@ public class ConfigController {
             }
             itemRepo.deleteById(itemId);
             return ResponseEntity.noContent().build();
-        }).orElse(ResponseEntity.notFound().build());
+        }).orElseGet(() -> ResponseEntity.notFound().build());
     }
 }


### PR DESCRIPTION
## Summary
- fix the deleteItem method in `ConfigController` to use `orElseGet`

## Testing
- `./mvnw -q -DskipTests package` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866ab4ab2d88327b7f8f1f1b37edb98