### PR TITLE
Implement stats endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,13 @@
             <version>2.4.0</version>
         </dependency>
 
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/forjix/cuentoskilla/controller/StatsController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/StatsController.java
@@ -1,0 +1,30 @@
+package com.forjix.cuentoskilla.controller;
+
+import com.forjix.cuentoskilla.model.DTOs.StatsDto;
+import com.forjix.cuentoskilla.service.StatsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/stats")
+@PreAuthorize("hasRole('ADMIN')")
+public class StatsController {
+
+    private final StatsService service;
+
+    public StatsController(StatsService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    @Operation(summary = "Aggregated statistics", parameters = {
+            @Parameter(name = "range", description = "Number of days or 'Nm' for last N months")})
+    public StatsDto getStats(@RequestParam String range) {
+        return service.getStats(range);
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/model/DTOs/StatsDto.java
+++ b/src/main/java/com/forjix/cuentoskilla/model/DTOs/StatsDto.java
@@ -1,0 +1,33 @@
+package com.forjix.cuentoskilla.model.DTOs;
+
+import java.util.List;
+
+public class StatsDto {
+    private List<Long> cuentos;
+    private List<Long> pedidos;
+    private List<Long> usuarios;
+
+    public List<Long> getCuentos() {
+        return cuentos;
+    }
+
+    public void setCuentos(List<Long> cuentos) {
+        this.cuentos = cuentos;
+    }
+
+    public List<Long> getPedidos() {
+        return pedidos;
+    }
+
+    public void setPedidos(List<Long> pedidos) {
+        this.pedidos = pedidos;
+    }
+
+    public List<Long> getUsuarios() {
+        return usuarios;
+    }
+
+    public void setUsuarios(List<Long> usuarios) {
+        this.usuarios = usuarios;
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/model/DTOs/TimeCount.java
+++ b/src/main/java/com/forjix/cuentoskilla/model/DTOs/TimeCount.java
@@ -1,0 +1,29 @@
+package com.forjix.cuentoskilla.model.DTOs;
+
+import java.time.LocalDateTime;
+
+public class TimeCount {
+    private LocalDateTime time;
+    private long count;
+
+    public TimeCount(LocalDateTime time, long count) {
+        this.time = time;
+        this.count = count;
+    }
+
+    public LocalDateTime getTime() {
+        return time;
+    }
+
+    public void setTime(LocalDateTime time) {
+        this.time = time;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/model/User.java
+++ b/src/main/java/com/forjix/cuentoskilla/model/User.java
@@ -2,6 +2,7 @@ package com.forjix.cuentoskilla.model;
 
 import jakarta.persistence.*;
 import org.hibernate.annotations.GenericGenerator; // Added
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID; // Added
@@ -25,6 +26,9 @@ public class User {
     private String documento; // DNI o RUC
 
     private String role;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
@@ -102,6 +106,14 @@ public class User {
         this.role = role;
     }
 
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
     public List<Order> getOrders() {
         return orders;
     }
@@ -112,6 +124,13 @@ public class User {
 
     @OneToMany(mappedBy = "user")
     private List<Order> orders;
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
 
     // Getters y setters
 }

--- a/src/main/java/com/forjix/cuentoskilla/repository/StatsRepository.java
+++ b/src/main/java/com/forjix/cuentoskilla/repository/StatsRepository.java
@@ -1,0 +1,55 @@
+package com.forjix.cuentoskilla.repository;
+
+import com.forjix.cuentoskilla.model.OrderStatus;
+import com.forjix.cuentoskilla.model.DTOs.TimeCount;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public class StatsRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public List<TimeCount> countCuentosByInterval(LocalDateTime start, LocalDateTime end, String unit) {
+        String jpql = "SELECT NEW com.forjix.cuentoskilla.model.DTOs.TimeCount(FUNCTION('date_trunc', :unit, c.fechaIngreso), COUNT(c)) " +
+                "FROM Cuento c WHERE c.fechaIngreso BETWEEN :start AND :end " +
+                "GROUP BY FUNCTION('date_trunc', :unit, c.fechaIngreso) " +
+                "ORDER BY FUNCTION('date_trunc', :unit, c.fechaIngreso)";
+        TypedQuery<TimeCount> query = em.createQuery(jpql, TimeCount.class);
+        query.setParameter("unit", unit);
+        query.setParameter("start", start);
+        query.setParameter("end", end);
+        return query.getResultList();
+    }
+
+    public List<TimeCount> countOrdersByStatusAndInterval(OrderStatus status, LocalDateTime start, LocalDateTime end, String unit) {
+        String jpql = "SELECT NEW com.forjix.cuentoskilla.model.DTOs.TimeCount(FUNCTION('date_trunc', :unit, o.created_at), COUNT(o)) " +
+                "FROM Order o WHERE o.created_at BETWEEN :start AND :end AND o.estado = :status " +
+                "GROUP BY FUNCTION('date_trunc', :unit, o.created_at) " +
+                "ORDER BY FUNCTION('date_trunc', :unit, o.created_at)";
+        TypedQuery<TimeCount> query = em.createQuery(jpql, TimeCount.class);
+        query.setParameter("unit", unit);
+        query.setParameter("start", start);
+        query.setParameter("end", end);
+        query.setParameter("status", status);
+        return query.getResultList();
+    }
+
+    public List<TimeCount> countUsersByInterval(LocalDateTime start, LocalDateTime end, String unit) {
+        String jpql = "SELECT NEW com.forjix.cuentoskilla.model.DTOs.TimeCount(FUNCTION('date_trunc', :unit, u.createdAt), COUNT(u)) " +
+                "FROM User u WHERE u.createdAt BETWEEN :start AND :end " +
+                "GROUP BY FUNCTION('date_trunc', :unit, u.createdAt) " +
+                "ORDER BY FUNCTION('date_trunc', :unit, u.createdAt)";
+        TypedQuery<TimeCount> query = em.createQuery(jpql, TimeCount.class);
+        query.setParameter("unit", unit);
+        query.setParameter("start", start);
+        query.setParameter("end", end);
+        return query.getResultList();
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/service/StatsService.java
+++ b/src/main/java/com/forjix/cuentoskilla/service/StatsService.java
@@ -1,0 +1,85 @@
+package com.forjix.cuentoskilla.service;
+
+import com.forjix.cuentoskilla.model.OrderStatus;
+import com.forjix.cuentoskilla.model.DTOs.StatsDto;
+import com.forjix.cuentoskilla.model.DTOs.TimeCount;
+import com.forjix.cuentoskilla.repository.StatsRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class StatsService {
+
+    private final StatsRepository repo;
+
+    public StatsService(StatsRepository repo) {
+        this.repo = repo;
+    }
+
+    private static class RangeInfo {
+        LocalDateTime start;
+        LocalDateTime end;
+        String unit;
+        ChronoUnit step;
+    }
+
+    private RangeInfo parseRange(String range) {
+        RangeInfo info = new RangeInfo();
+        LocalDate today = LocalDate.now();
+        if (range != null && range.endsWith("m")) {
+            int months = Integer.parseInt(range.substring(0, range.length() - 1));
+            info.unit = "month";
+            info.step = ChronoUnit.MONTHS;
+            info.end = today.withDayOfMonth(1).atStartOfDay();
+            info.start = info.end.minusMonths(months - 1);
+        } else {
+            int days = Integer.parseInt(range);
+            if (days >= 365) {
+                info.unit = "month";
+                info.step = ChronoUnit.MONTHS;
+                info.end = today.withDayOfMonth(1).atStartOfDay();
+                info.start = info.end.minusMonths(days / 30L - 1);
+            } else {
+                info.unit = "day";
+                info.step = ChronoUnit.DAYS;
+                info.end = today.atStartOfDay();
+                info.start = info.end.minusDays(days - 1);
+            }
+        }
+        return info;
+    }
+
+    private List<Long> fill(List<TimeCount> counts, RangeInfo info) {
+        Map<LocalDateTime, Long> map = new HashMap<>();
+        for (TimeCount tc : counts) {
+            map.put(tc.getTime(), tc.getCount());
+        }
+        List<Long> result = new ArrayList<>();
+        LocalDateTime point = info.start;
+        while (!point.isAfter(info.end)) {
+            result.add(map.getOrDefault(point, 0L));
+            point = point.plus(1, info.step);
+        }
+        return result;
+    }
+
+    public StatsDto getStats(String range) {
+        RangeInfo info = parseRange(range);
+        List<TimeCount> cuentos = repo.countCuentosByInterval(info.start, info.end, info.unit);
+        List<TimeCount> pedidos = repo.countOrdersByStatusAndInterval(OrderStatus.valueOf("EN_PROCESO"), info.start, info.end, info.unit);
+        List<TimeCount> usuarios = repo.countUsersByInterval(info.start, info.end, info.unit);
+
+        StatsDto dto = new StatsDto();
+        dto.setCuentos(fill(cuentos, info));
+        dto.setPedidos(fill(pedidos, info));
+        dto.setUsuarios(fill(usuarios, info));
+        return dto;
+    }
+}

--- a/src/test/java/com/forjix/cuentoskilla/controller/StatsControllerTest.java
+++ b/src/test/java/com/forjix/cuentoskilla/controller/StatsControllerTest.java
@@ -1,0 +1,45 @@
+package com.forjix.cuentoskilla.controller;
+
+import com.forjix.cuentoskilla.config.JwtUtil;
+import com.forjix.cuentoskilla.model.DTOs.StatsDto;
+import com.forjix.cuentoskilla.service.StatsService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Collections;
+
+@WebMvcTest(StatsController.class)
+public class StatsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StatsService service;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    public void testGetStats() throws Exception {
+        StatsDto dto = new StatsDto();
+        dto.setCuentos(Collections.emptyList());
+        dto.setPedidos(Collections.emptyList());
+        dto.setUsuarios(Collections.emptyList());
+        Mockito.when(service.getStats("7")).thenReturn(dto);
+        Mockito.when(jwtUtil.validateToken(Mockito.anyString())).thenReturn(true);
+        Mockito.when(jwtUtil.extractUsername(Mockito.anyString())).thenReturn("admin");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/admin/stats")
+                        .header("Authorization", "Bearer " + jwtUtil.generateToken("admin"))
+                        .param("range", "7"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.cuentos").exists());
+    }
+}

--- a/src/test/java/com/forjix/cuentoskilla/service/StatsServiceTest.java
+++ b/src/test/java/com/forjix/cuentoskilla/service/StatsServiceTest.java
@@ -1,0 +1,37 @@
+package com.forjix.cuentoskilla.service;
+
+import com.forjix.cuentoskilla.model.OrderStatus;
+import com.forjix.cuentoskilla.model.DTOs.StatsDto;
+import com.forjix.cuentoskilla.model.DTOs.TimeCount;
+import com.forjix.cuentoskilla.repository.StatsRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+
+public class StatsServiceTest {
+
+    @Test
+    public void testGetStats7Days() {
+        StatsRepository repo = Mockito.mock(StatsRepository.class);
+        LocalDateTime now = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+        Mockito.when(repo.countCuentosByInterval(any(), any(), anyString()))
+                .thenReturn(List.of(new TimeCount(now.minusDays(1), 2L)));
+        Mockito.when(repo.countOrdersByStatusAndInterval(any(), any(), any(), anyString()))
+                .thenReturn(List.of(new TimeCount(now.minusDays(1), 1L)));
+        Mockito.when(repo.countUsersByInterval(any(), any(), anyString()))
+                .thenReturn(List.of(new TimeCount(now.minusDays(1), 3L)));
+        StatsService service = new StatsService(repo);
+        StatsDto dto = service.getStats("7");
+        assertEquals(7, dto.getCuentos().size());
+        assertEquals(7, dto.getPedidos().size());
+        assertEquals(7, dto.getUsuarios().size());
+        assertEquals(2L, dto.getCuentos().get(5));
+        assertEquals(1L, dto.getPedidos().get(5));
+        assertEquals(3L, dto.getUsuarios().get(5));
+    }
+}


### PR DESCRIPTION
## Summary
- add `StatsDto` and `TimeCount`
- add controller and service to expose `/api/admin/stats`
- add repository for stats queries
- store user creation timestamp
- provide unit and controller tests
- enable test dependencies

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867b8907d68832781e974db99e54f8e