### PR TITLE
Implement voucher upload validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # Cuentos de Killa - Backend
 Proyecto base en Spring Boot 3.3 con conexión a PostgreSQL.
+
+## Configuración
+
+Propiedades relevantes en `application.yml`:
+
+```yaml
+file:
+  upload-dir: ./uploads/vouchers
+upload:
+  max-size: 5242880 # bytes (5 MB)
+storage:
+  provider: local
+```
+
+`upload.max-size` define el límite de tamaño de los archivos subidos.
+`storage.provider` permitirá seleccionar el proveedor (solo `local` soportado por ahora).

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
+        <!-- Actuator for metrics -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
         <!-- PostgreSQL -->
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/src/main/java/com/forjix/cuentoskilla/controller/OrderController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/OrderController.java
@@ -20,9 +20,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal; // Added
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -175,10 +177,11 @@ public class OrderController {
         }
     }
 
-    @PostMapping("/voucher")
+    @PostMapping("/{id}/voucher")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<?> uploadVoucher(
-            @RequestParam("file") MultipartFile file,
-            @RequestParam("idpedido") long orderId, // Changed to UUID
+            @PathVariable("id") long orderId,
+            @RequestPart("file") MultipartFile file,
             @RequestParam(name = "dispositivo", required = false, defaultValue = "Desconocido") String dispositivo,
             HttpServletRequest request, @AuthenticationPrincipal User user) {
         
@@ -202,19 +205,19 @@ public class OrderController {
                 return ResponseEntity.badRequest().body(Map.of("error", "Valid Order ID is required."));
             }
 
-            logger.info("Attempting to upload voucher for orderId: {}, fileName: {}, ip: {}, device: {} by user {}", 
+            logger.info("Attempting to upload voucher for orderId: {}, fileName: {}, ip: {}, device: {} by user {}",
                         orderId, originalFileName, ip, dispositivo, user.getId());
-            
+
             // storageService.store should also verify user ownership of the orderId
             Voucher voucher = storageService.store(file, orderId, originalFileName, contentType, ip, dispositivo, fileSize);
             
-            logger.info("Voucher uploaded successfully for orderId: {}. Voucher ID: {}, FileName: {} by user {}", 
+            logger.info("Voucher uploaded successfully for orderId: {}. Voucher ID: {}, FileName: {} by user {}",
                         orderId, voucher.getId(), voucher.getNombreArchivo(), user.getId());
-            
-            return ResponseEntity.ok(Map.of(
-                "message", "Voucher uploaded successfully!", 
-                "voucherId", voucher.getId(),
-                "fileName", voucher.getNombreArchivo()
+
+            return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "id", voucher.getId(),
+                "fileUrl", voucher.getFilePath(),
+                "status", voucher.getOrder().getEstado().toString()
             ));
         } catch (StorageException e) {
             logger.error("StorageException for orderId {} by user {}: {}", orderId, user.getId(), e.getMessage(), e);

--- a/src/main/java/com/forjix/cuentoskilla/exception/ApiError.java
+++ b/src/main/java/com/forjix/cuentoskilla/exception/ApiError.java
@@ -1,0 +1,26 @@
+package com.forjix.cuentoskilla.exception;
+
+import java.time.Instant;
+
+public class ApiError {
+    private final String code;
+    private final String message;
+    private final Instant timestamp = Instant.now();
+
+    public ApiError(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/exception/RestExceptionHandler.java
+++ b/src/main/java/com/forjix/cuentoskilla/exception/RestExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.forjix.cuentoskilla.exception;
+
+import com.forjix.cuentoskilla.service.storage.StorageException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiError> handleMaxSize(MaxUploadSizeExceededException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ApiError("MAX_UPLOAD_SIZE_EXCEEDED", "File too large"));
+    }
+
+    @ExceptionHandler(StorageException.class)
+    public ResponseEntity<ApiError> handleStorage(StorageException ex) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        String code = ex.getMessage();
+        if (!"INVALID_FILE".equals(code) && !"MAX_UPLOAD_SIZE_EXCEEDED".equals(code)) {
+            code = "STORAGE_ERROR";
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return ResponseEntity.status(status)
+                .body(new ApiError(code, ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleGeneric(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ApiError("INTERNAL_ERROR", ex.getMessage()));
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/model/OrderStatus.java
+++ b/src/main/java/com/forjix/cuentoskilla/model/OrderStatus.java
@@ -3,6 +3,7 @@ package com.forjix.cuentoskilla.model;
 public enum OrderStatus {
     GENERADO,
     PAGO_PENDIENTE,
+    PAGO_ENVIADO,
     PAGADO,
     VERIFICADO,
     EMPAQUETADO,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,12 @@ spring:
 file:
   upload-dir: ./uploads/vouchers
 
+upload:
+  max-size: 5242880
+
+storage:
+  provider: local
+
 mercadopago:
   access-token: YOUR_ACCESS_TOKEN # Existing
   back-urls:

--- a/src/test/java/com/forjix/cuentoskilla/service/storage/FileSystemStorageServiceTest.java
+++ b/src/test/java/com/forjix/cuentoskilla/service/storage/FileSystemStorageServiceTest.java
@@ -1,0 +1,88 @@
+package com.forjix.cuentoskilla.service.storage;
+
+import com.forjix.cuentoskilla.model.Order;
+import com.forjix.cuentoskilla.model.OrderStatus;
+import com.forjix.cuentoskilla.model.Voucher;
+import com.forjix.cuentoskilla.repository.OrderRepository;
+import com.forjix.cuentoskilla.repository.VoucherRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+
+public class FileSystemStorageServiceTest {
+
+    private VoucherRepository voucherRepository;
+    private OrderRepository orderRepository;
+    private MeterRegistry meterRegistry;
+    private Counter counter;
+    private FileSystemStorageService service;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        voucherRepository = Mockito.mock(VoucherRepository.class);
+        orderRepository = Mockito.mock(OrderRepository.class);
+        meterRegistry = Mockito.mock(MeterRegistry.class);
+        counter = Mockito.mock(Counter.class);
+        Mockito.when(meterRegistry.counter(anyString())).thenReturn(counter);
+
+        service = new FileSystemStorageService(voucherRepository, orderRepository, meterRegistry);
+        // set uploadDir manually
+        Path temp = Files.createTempDirectory("vtest");
+        java.lang.reflect.Field field = FileSystemStorageService.class.getDeclaredField("uploadDir");
+        field.setAccessible(true);
+        field.set(service, temp.toString());
+        service.init();
+    }
+
+    @Test
+    public void testStoreValidFile() {
+        Order order = new Order();
+        order.setId(1L);
+        order.setEstado(OrderStatus.PAGO_PENDIENTE);
+        Mockito.when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        Mockito.when(voucherRepository.save(any(Voucher.class))).thenAnswer(inv -> inv.getArgument(0));
+        Mockito.when(orderRepository.save(any(Order.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", new byte[]{1,2,3});
+        Voucher v = service.store(file, 1L, file.getOriginalFilename(), file.getContentType(), "127.0.0.1", "test", file.getSize());
+        assertNotNull(v.getFilePath());
+        assertEquals(OrderStatus.PAGO_ENVIADO, order.getEstado());
+    }
+
+    @Test
+    public void testInvalidExtension() {
+        Order order = new Order();
+        order.setId(1L);
+        order.setEstado(OrderStatus.PAGO_PENDIENTE);
+        Mockito.when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+        MockMultipartFile file = new MockMultipartFile("file", "test.txt", "text/plain", new byte[]{1});
+        StorageException ex = assertThrows(StorageException.class, () ->
+                service.store(file, 1L, file.getOriginalFilename(), file.getContentType(), "ip", "dev", file.getSize()));
+        assertEquals("INVALID_FILE", ex.getMessage());
+    }
+
+    @Test
+    public void testMaxSizeExceeded() {
+        Order order = new Order();
+        order.setId(1L);
+        order.setEstado(OrderStatus.PAGO_PENDIENTE);
+        Mockito.when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+        byte[] large = new byte[6 * 1024 * 1024];
+        MockMultipartFile file = new MockMultipartFile("file", "big.jpg", "image/jpeg", large);
+        StorageException ex = assertThrows(StorageException.class, () ->
+                service.store(file, 1L, file.getOriginalFilename(), file.getContentType(), "ip", "dev", file.getSize()));
+        assertEquals("MAX_UPLOAD_SIZE_EXCEEDED", ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- add order state `PAGO_ENVIADO`
- validate file size and extension when storing vouchers
- expose `POST /api/orders/{id}/voucher` endpoint
- handle errors consistently with `RestExceptionHandler`
- document configuration properties
- add unit tests for file storage
- fix missing imports for voucher endpoint

## Testing
- `./mvnw -q test` *(fails to download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867f1b1cb288327bad310915a06c2de