### PR TITLE
Enable Sentry error tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ storage:
 
 `upload.max-size` define el límite de tamaño de los archivos subidos.
 `storage.provider` permitirá seleccionar el proveedor (solo `local` soportado por ahora).
+
+## Sentry
+
+Se incluye la dependencia **Sentry** para registrar errores en todos los endpoints.
+Defina la variable de entorno `SENTRY_DSN` con el DSN de su proyecto para habilitar los reportes.
+Para que el plugin de Maven pueda subir el código fuente a Sentry debe
+establecer la variable `SENTRY_AUTH_TOKEN` con un token válido.

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,13 @@
             <version>2.2.22</version>
         </dependency>
 
+        <!-- Sentry for error tracking -->
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-spring-boot-starter</artifactId>
+            <version>7.5.0</version>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -125,6 +132,26 @@
                     <source>17</source>
                     <target>17</target>
                 </configuration>
+            </plugin>
+            <!-- Plugin para subir el bundle de código fuente a Sentry -->
+            <plugin>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry-maven-plugin</artifactId>
+                <version>0.6.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <debugSentryCli>true</debugSentryCli>
+                    <org>cuentos-de-killa</org>
+                    <project>java-spring-boot</project>
+                    <authToken>${env.SENTRY_AUTH_TOKEN}</authToken>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>uploadSourceBundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/forjix/cuentoskilla/exception/RestExceptionHandler.java
+++ b/src/main/java/com/forjix/cuentoskilla/exception/RestExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.forjix.cuentoskilla.exception;
 
 import com.forjix.cuentoskilla.service.storage.StorageException;
+import io.sentry.Sentry;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,6 +13,7 @@ public class RestExceptionHandler {
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<ApiError> handleMaxSize(MaxUploadSizeExceededException ex) {
+        Sentry.captureException(ex);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ApiError("MAX_UPLOAD_SIZE_EXCEEDED", "File too large"));
     }
@@ -24,12 +26,14 @@ public class RestExceptionHandler {
             code = "STORAGE_ERROR";
             status = HttpStatus.INTERNAL_SERVER_ERROR;
         }
+        Sentry.captureException(ex);
         return ResponseEntity.status(status)
                 .body(new ApiError(code, ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiError> handleGeneric(Exception ex) {
+        Sentry.captureException(ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ApiError("INTERNAL_ERROR", ex.getMessage()));
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,9 @@ mercadopago:
     failure: https://your-frontend.com/payment/failure
     pending: https://your-frontend.com/payment/pending
   notification-url: https://your-api-backend.com/api/webhooks/mercadopago
+
+sentry:
+  dsn: https://206c3de140ffe2f6be2200ed522250b1@o4509612268912640.ingest.us.sentry.io/4509612333727744
+  send-default-pii: true
+  logging:
+    minimum-event-level: error


### PR DESCRIPTION
## Summary
- add `sentry-spring-boot-starter` dependency
- send exceptions to Sentry in `RestExceptionHandler`
- configure Sentry properties
- document Sentry configuration
- add Sentry Maven plugin with token-based auth

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868402523b48327bd55358334502361