### PR TITLE
Fix build failure when SENTRY_AUTH_TOKEN is not defined

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,26 +133,41 @@
                     <target>17</target>
                 </configuration>
             </plugin>
-            <!-- Plugin para subir el bundle de código fuente a Sentry -->
-            <plugin>
-                <groupId>io.sentry</groupId>
-                <artifactId>sentry-maven-plugin</artifactId>
-                <version>0.6.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <debugSentryCli>true</debugSentryCli>
-                    <org>cuentos-de-killa</org>
-                    <project>java-spring-boot</project>
-                    <authToken>${env.SENTRY_AUTH_TOKEN}</authToken>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>uploadSourceBundle</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>sentry</id>
+            <activation>
+                <property>
+                    <name>env.SENTRY_AUTH_TOKEN</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Plugin para subir el bundle de código fuente a Sentry -->
+                    <plugin>
+                        <groupId>io.sentry</groupId>
+                        <artifactId>sentry-maven-plugin</artifactId>
+                        <version>0.6.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <debugSentryCli>true</debugSentryCli>
+                            <org>cuentos-de-killa</org>
+                            <project>java-spring-boot</project>
+                            <authToken>${env.SENTRY_AUTH_TOKEN}</authToken>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>uploadSourceBundle</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Summary
- avoid running `sentry-maven-plugin` if no auth token is provided by wrapping
  the plugin inside a Maven profile that only activates when `SENTRY_AUTH_TOKEN`
  is set

## Testing
- `./mvnw -ntp -q test` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68684e7ff0d483278863dd1e3415e05f