### PR TITLE
Add order status endpoint

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/controller/OrderController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/OrderController.java
@@ -65,7 +65,7 @@ public class OrderController {
         return ResponseEntity.ok(service.getOrdersByUser(user.getId()));
     }
     @GetMapping("/{id}")
-    public ResponseEntity<Order> getOrder(@PathVariable long id, @AuthenticationPrincipal UserDetailsImpl user) {        
+    public ResponseEntity<Order> getOrder(@PathVariable long id, @AuthenticationPrincipal UserDetailsImpl user) {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -75,6 +75,21 @@ public class OrderController {
         }
         System.out.println("getOrder getOrderByIdAndUser() ejecutado");
         return ResponseEntity.ok(order);
+    }
+
+    @GetMapping("/{id}/status")
+    public ResponseEntity<?> getOrderStatus(@PathVariable long id, @AuthenticationPrincipal UserDetailsImpl user) {
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        try {
+            OrderStatus status = service.getOrderStatus(id, user.getId());
+            return ResponseEntity.ok(Map.of("estado", status.toString()));
+        } catch (SecurityException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", e.getMessage()));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
     }
 
     @PostMapping("/{id}/pay")

--- a/src/main/java/com/forjix/cuentoskilla/service/OrderService.java
+++ b/src/main/java/com/forjix/cuentoskilla/service/OrderService.java
@@ -237,7 +237,17 @@ public class OrderService {
         PedidoDTO pedidoDTO = mapToPedidoDTO(order);
         return mercadoPagoService.createPaymentPreference(pedidoDTO, order.getId()).getInitPoint();
 
-    
+
+    }
+
+    @Transactional(readOnly = true)
+    public OrderStatus getOrderStatus(Long orderId, Long userId) {
+        Order order = orderRepo.findById(orderId)
+                .orElseThrow(() -> new RuntimeException("Order not found with ID: " + orderId));
+        if (!order.getUser().getId().equals(userId)) {
+            throw new SecurityException("User not authorized to access this order.");
+        }
+        return order.getEstado();
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- implement `getOrderStatus` method in `OrderService`
- expose new endpoint `/api/orders/{id}/status` in `OrderController`

## Testing
- `./mvnw -q test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_6868b2e2df948327b90dd53f759d81ae