### PR TITLE
Update Sentry dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Se incluye la dependencia **Sentry** para registrar errores en todos los endpoin
 Defina la variable de entorno `SENTRY_DSN` con el DSN de su proyecto para habilitar los reportes.
 Para que el plugin de Maven pueda subir el código fuente a Sentry debe
 establecer la variable `SENTRY_AUTH_TOKEN` con un token válido.
+Se utiliza `sentry-spring-boot-starter` 7.15.0 que es compatible con Spring Boot 3.3.

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-spring-boot-starter</artifactId>
-            <version>7.5.0</version>
+            <version>7.15.0</version>
         </dependency>
 
         <!-- Testing -->
@@ -150,7 +150,7 @@
                     <plugin>
                         <groupId>io.sentry</groupId>
                         <artifactId>sentry-maven-plugin</artifactId>
-                        <version>0.6.0</version>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <debugSentryCli>true</debugSentryCli>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ mercadopago:
   notification-url: https://your-api-backend.com/api/webhooks/mercadopago
 
 sentry:
-  dsn: https://206c3de140ffe2f6be2200ed522250b1@o4509612268912640.ingest.us.sentry.io/4509612333727744
+  dsn: ${SENTRY_DSN:}
   send-default-pii: true
   logging:
     minimum-event-level: error


### PR DESCRIPTION
## Summary
- update sentry-spring-boot-starter to 7.15.0
- update Sentry Maven plugin
- read DSN from env variable
- clarify Sentry section in README

## Testing
- `./mvnw -q test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868b0ad4d6883279edc0fb561934b05