### PR TITLE
Implement Firebase voucher storage

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/config/FirebaseConfig.java
+++ b/src/main/java/com/forjix/cuentoskilla/config/FirebaseConfig.java
@@ -4,6 +4,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.FileInputStream;
@@ -12,12 +13,21 @@ import java.io.IOException;
 @Configuration
 public class FirebaseConfig {
 
+    @Value("${firebase.credentials}")
+    private String credentialsPath;
+
+    @Value("${firebase.bucket}")
+    private String bucketName;
+
     @PostConstruct
     public void init() {
-        try {
-            FileInputStream serviceAccount = new FileInputStream("firebase-service-account.json");
+        if (!FirebaseApp.getApps().isEmpty()) {
+            return;
+        }
+        try (FileInputStream serviceAccount = new FileInputStream(credentialsPath)) {
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .setStorageBucket(bucketName)
                     .build();
             FirebaseApp.initializeApp(options);
         } catch (IOException e) {

--- a/src/main/java/com/forjix/cuentoskilla/controller/PaymentVoucherController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/PaymentVoucherController.java
@@ -1,0 +1,82 @@
+package com.forjix.cuentoskilla.controller;
+
+import com.forjix.cuentoskilla.config.UserDetailsImpl;
+import com.forjix.cuentoskilla.model.Order;
+import com.forjix.cuentoskilla.model.OrderStatus;
+import com.forjix.cuentoskilla.model.PaymentVoucher;
+import com.forjix.cuentoskilla.model.Rol;
+import com.forjix.cuentoskilla.repository.OrderRepository;
+import com.forjix.cuentoskilla.service.PaymentVoucherService;
+import com.forjix.cuentoskilla.service.storage.StorageException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/pedidos")
+public class PaymentVoucherController {
+
+    private final PaymentVoucherService voucherService;
+    private final OrderRepository orderRepository;
+
+    public PaymentVoucherController(PaymentVoucherService voucherService, OrderRepository orderRepository) {
+        this.voucherService = voucherService;
+        this.orderRepository = orderRepository;
+    }
+
+    @PostMapping("/{id}/voucher")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<?> upload(@PathVariable("id") Long orderId,
+                                    @RequestParam("file") MultipartFile file,
+                                    @AuthenticationPrincipal UserDetailsImpl user) {
+        Order order = orderRepository.findById(orderId).orElse(null);
+        if (order == null) return ResponseEntity.notFound().build();
+        if (!order.getUser().getId().equals(user.getId())) return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        if (order.getEstado() == OrderStatus.PAGADO) return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error","Order already paid"));
+        try {
+            PaymentVoucher voucher = voucherService.upload(orderId, file);
+            return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                    "id", voucher.getId(),
+                    "filename", voucher.getFilename(),
+                    "mimeType", voucher.getMimeType(),
+                    "size", voucher.getSize(),
+                    "firebasePath", voucher.getFirebasePath(),
+                    "uploadDate", voucher.getUploadDate().toString()
+            ));
+        } catch (StorageException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/{id}/voucher-url")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> getUrl(@PathVariable("id") Long orderId) {
+        return voucherService.findByOrder(orderId)
+                .map(v -> ResponseEntity.ok(Map.of("url", voucherService.generateSignedUrl(v))))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+    }
+
+    @DeleteMapping("/{id}/voucher")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
+    public ResponseEntity<?> delete(@PathVariable("id") Long orderId,
+                                    @AuthenticationPrincipal UserDetailsImpl user) {
+        PaymentVoucher voucher = voucherService.findByOrder(orderId).orElse(null);
+        if (voucher == null) return ResponseEntity.notFound().build();
+        Order order = voucher.getOrder();
+        if (!user.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))) {
+            if (!order.getUser().getId().equals(user.getId())) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+            if (!(order.getEstado() == OrderStatus.PAGO_PENDIENTE || order.getEstado() == OrderStatus.PAGO_ENVIADO)) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+            }
+        }
+        voucherService.delete(voucher);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/model/PaymentVoucher.java
+++ b/src/main/java/com/forjix/cuentoskilla/model/PaymentVoucher.java
@@ -1,0 +1,43 @@
+package com.forjix.cuentoskilla.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payment_vouchers")
+public class PaymentVoucher {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    private String filename;
+    private String mimeType;
+    private long size;
+    private String firebasePath;
+    private LocalDateTime uploadDate;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Order getOrder() { return order; }
+    public void setOrder(Order order) { this.order = order; }
+
+    public String getFilename() { return filename; }
+    public void setFilename(String filename) { this.filename = filename; }
+
+    public String getMimeType() { return mimeType; }
+    public void setMimeType(String mimeType) { this.mimeType = mimeType; }
+
+    public long getSize() { return size; }
+    public void setSize(long size) { this.size = size; }
+
+    public String getFirebasePath() { return firebasePath; }
+    public void setFirebasePath(String firebasePath) { this.firebasePath = firebasePath; }
+
+    public LocalDateTime getUploadDate() { return uploadDate; }
+    public void setUploadDate(LocalDateTime uploadDate) { this.uploadDate = uploadDate; }
+}

--- a/src/main/java/com/forjix/cuentoskilla/repository/PaymentVoucherRepository.java
+++ b/src/main/java/com/forjix/cuentoskilla/repository/PaymentVoucherRepository.java
@@ -1,0 +1,10 @@
+package com.forjix.cuentoskilla.repository;
+
+import com.forjix.cuentoskilla.model.PaymentVoucher;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentVoucherRepository extends JpaRepository<PaymentVoucher, Long> {
+    Optional<PaymentVoucher> findByOrder_Id(Long orderId);
+}

--- a/src/main/java/com/forjix/cuentoskilla/service/PaymentVoucherService.java
+++ b/src/main/java/com/forjix/cuentoskilla/service/PaymentVoucherService.java
@@ -1,0 +1,82 @@
+package com.forjix.cuentoskilla.service;
+
+import com.forjix.cuentoskilla.model.Order;
+import com.forjix.cuentoskilla.model.OrderStatus;
+import com.forjix.cuentoskilla.model.PaymentVoucher;
+import com.forjix.cuentoskilla.repository.OrderRepository;
+import com.forjix.cuentoskilla.repository.PaymentVoucherRepository;
+import com.forjix.cuentoskilla.service.storage.FirebaseStorageService;
+import com.forjix.cuentoskilla.service.storage.StorageException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class PaymentVoucherService {
+
+    private final PaymentVoucherRepository voucherRepository;
+    private final OrderRepository orderRepository;
+    private final FirebaseStorageService storageService;
+
+    @Value("${upload.max-size:5242880}")
+    private long maxSize;
+
+    public PaymentVoucherService(PaymentVoucherRepository voucherRepository,
+                                 OrderRepository orderRepository,
+                                 FirebaseStorageService storageService) {
+        this.voucherRepository = voucherRepository;
+        this.orderRepository = orderRepository;
+        this.storageService = storageService;
+    }
+
+    public PaymentVoucher upload(Long orderId, MultipartFile file) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new StorageException("Order not found"));
+
+        String ext = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        if (ext == null) throw new StorageException("INVALID_FILE");
+        String mime = file.getContentType();
+        if (!("image/png".equals(mime) || "image/jpeg".equals(mime) || "application/pdf".equals(mime))) {
+            throw new StorageException("INVALID_FILE");
+        }
+        if (file.getSize() > maxSize) {
+            throw new StorageException("MAX_UPLOAD_SIZE_EXCEEDED");
+        }
+
+        String filename = System.currentTimeMillis() + "." + ext;
+        String path = "vouchers/" + orderId + "/" + filename;
+        storageService.upload(file, path);
+
+        PaymentVoucher voucher = new PaymentVoucher();
+        voucher.setOrder(order);
+        voucher.setFilename(filename);
+        voucher.setMimeType(mime);
+        voucher.setSize(file.getSize());
+        voucher.setFirebasePath(path);
+        voucher.setUploadDate(LocalDateTime.now());
+
+        PaymentVoucher saved = voucherRepository.save(voucher);
+
+        order.setEstado(OrderStatus.PAGO_ENVIADO);
+        orderRepository.save(order);
+
+        return saved;
+    }
+
+    public Optional<PaymentVoucher> findByOrder(Long orderId) {
+        return voucherRepository.findByOrder_Id(orderId);
+    }
+
+    public String generateSignedUrl(PaymentVoucher voucher) {
+        return storageService.generateSignedUrl(voucher.getFirebasePath());
+    }
+
+    public void delete(PaymentVoucher voucher) {
+        storageService.delete(voucher.getFirebasePath());
+        voucherRepository.delete(voucher);
+    }
+}

--- a/src/main/java/com/forjix/cuentoskilla/service/storage/FirebaseStorageService.java
+++ b/src/main/java/com/forjix/cuentoskilla/service/storage/FirebaseStorageService.java
@@ -1,0 +1,38 @@
+package com.forjix.cuentoskilla.service.storage;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.firebase.cloud.StorageClient;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class FirebaseStorageService {
+
+    public String upload(MultipartFile file, String path) {
+        try {
+            Blob blob = StorageClient.getInstance().bucket().create(path, file.getBytes(), file.getContentType());
+            return blob.getBlobId().getName();
+        } catch (IOException e) {
+            throw new StorageException("Failed to upload file to Firebase", e);
+        }
+    }
+
+    public String generateSignedUrl(String path) {
+        BlobInfo blobInfo = BlobInfo.newBuilder(StorageClient.getInstance().bucket().getName(), path).build();
+        URL url = StorageClient.getInstance().bucket().getStorage()
+                .signUrl(blobInfo, 10, TimeUnit.MINUTES);
+        return url.toString();
+    }
+
+    public void delete(String path) {
+        Blob blob = StorageClient.getInstance().bucket().get(path);
+        if (blob != null && !blob.delete()) {
+            throw new StorageException("Failed to delete file from Firebase");
+        }
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,6 +11,10 @@ spring:
 file:
   upload-dir: ./uploads/vouchers
 
+firebase:
+  credentials: ${FIREBASE_CREDENTIALS:firebase-adminsdk.json}
+  bucket: ${FIREBASE_BUCKET:}
+
 mercadopago:
   access-token: YOUR_ACCESS_TOKEN # Existing
   back-urls:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,6 +14,10 @@ spring:
 file:
   upload-dir: uploads/vouchers
 
+firebase:
+  credentials: ${FIREBASE_CREDENTIALS:firebase-adminsdk.json}
+  bucket: ${FIREBASE_BUCKET:}
+
 mercadopago:
   access-token: YOUR_ACCESS_TOKEN # Existing
   back-urls:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,10 @@ upload:
 storage:
   provider: local
 
+firebase:
+  credentials: ${FIREBASE_CREDENTIALS:firebase-adminsdk.json}
+  bucket: ${FIREBASE_BUCKET:}
+
 mercadopago:
   access-token: YOUR_ACCESS_TOKEN # Existing
   back-urls:


### PR DESCRIPTION
## Summary
- configure Firebase app with credentials and bucket properties
- create PaymentVoucher entity and repository
- implement FirebaseStorageService and service layer
- add controller for voucher endpoints
- add firebase configs in application.yml files

## Testing
- `bash mvnw -q -DskipTests=false test` *(fails: mvnw can't download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686b386aaaf8832780ce2e6baf88df3f