### PR TITLE
Add placeholder Firebase credentials file

### DIFF
--- a/firebase-adminsdk.json
+++ b/firebase-adminsdk.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "YOUR_PROJECT_ID",
+  "private_key_id": "YOUR_PRIVATE_KEY_ID",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY\n-----END PRIVATE KEY-----\n",
+  "client_email": "firebase-adminsdk@YOUR_PROJECT_ID.iam.gserviceaccount.com",
+  "client_id": "YOUR_CLIENT_ID",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk%40YOUR_PROJECT_ID.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
## Summary
- add a placeholder `firebase-adminsdk.json` with sample fields for Firebase credentials

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch Maven due to missing internet access)*

------
https://chatgpt.com/codex/tasks/task_e_686d2e5f67f88327a052517ea7a00310