### PR TITLE
Fix StorageException handling order

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/controller/OrderController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/OrderController.java
@@ -294,11 +294,11 @@ public class OrderController {
             ));
         } catch (SecurityException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        } catch (RuntimeException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         } catch (StorageException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Map.of("error", e.getMessage()));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
     }
 }


### PR DESCRIPTION
## Summary
- resolve Java compilation error by catching `StorageException` before `RuntimeException`

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch apache-maven-3.8.6-bin.zip)*
- `./mvnw -q test` *(fails: Failed to fetch apache-maven-3.8.6-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68701940406c83279e3029f913118c9f