### PR TITLE
Fix ambiguous bean injection in EndpointLogger

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/config/EndpointLogger.java
+++ b/src/main/java/com/forjix/cuentoskilla/config/EndpointLogger.java
@@ -3,6 +3,7 @@ package com.forjix.cuentoskilla.config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
@@ -19,7 +20,8 @@ public class EndpointLogger implements ApplicationListener<ApplicationReadyEvent
     private final RequestMappingHandlerMapping handlerMapping;
 
     @Autowired
-    public EndpointLogger(RequestMappingHandlerMapping handlerMapping) {
+    public EndpointLogger(@Qualifier("requestMappingHandlerMapping")
+                          RequestMappingHandlerMapping handlerMapping) {
         this.handlerMapping = handlerMapping;
     }
 


### PR DESCRIPTION
## Summary
- specify correct `RequestMappingHandlerMapping` bean to avoid ambiguous injection

## Testing
- `./mvnw -q test` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6870384b83448327ac20828df70e7786