### PR TITLE
feat: add cuento service layer

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/controller/CuentoController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/CuentoController.java
@@ -1,7 +1,7 @@
 package com.forjix.cuentoskilla.controller;
 
 import com.forjix.cuentoskilla.model.Cuento;
-import com.forjix.cuentoskilla.repository.CuentoRepository;
+import com.forjix.cuentoskilla.service.CuentoService;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,22 +13,22 @@ import java.util.List;
 @CrossOrigin
 public class CuentoController {
 
-    private final CuentoRepository cuentoRepository;
+    private final CuentoService cuentoService;
 
-    public CuentoController(CuentoRepository cuentoRepository) {
-        this.cuentoRepository = cuentoRepository;
+    public CuentoController(CuentoService cuentoService) {
+        this.cuentoService = cuentoService;
     }
 
     @GetMapping
     public List<Cuento> getAll() {
         System.out.println("GetMapping getAll() ejecutado");
-        return cuentoRepository.findAll();
+        return cuentoService.findAll();
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<Cuento> getByIdCuentos(@PathVariable Long id) {
         System.out.println("GetMapping getByIdCuentos() ejecutado");
-        return cuentoRepository.findById(id)
+        return cuentoService.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }  
@@ -36,34 +36,28 @@ public class CuentoController {
     @PostMapping
     public Cuento create(@RequestBody Cuento cuento) {
         System.out.println("PostMapping create() ejecutado");
-        return cuentoRepository.save(cuento);
+        return cuentoService.save(cuento);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<Cuento> update(@PathVariable Long id, @RequestBody Cuento cuento) {
         System.out.println("PutMapping update() ejecutado");
-        return cuentoRepository.findById(id)
-                .map(existing -> {
-                    cuento.setId(id);
-                    return ResponseEntity.ok(cuentoRepository.save(cuento));
-                })
+        return cuentoService.update(id, cuento)
+                .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @PutMapping("/{id}/estado")
     public ResponseEntity<Cuento> updateEstado(@PathVariable Long id, @RequestBody Cuento cuento) {
         System.out.println("PutMapping updateEstado() ejecutado");
-        return cuentoRepository.findById(id)
-                .map(existing -> {
-                    existing.setHabilitado(cuento.isHabilitado());
-                    return ResponseEntity.ok(cuentoRepository.save(existing));
-                })
+        return cuentoService.updateEstado(id, cuento)
+                .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         System.out.println("DeleteMapping delete() ejecutado");
-        cuentoRepository.deleteById(id);
+        cuentoService.delete(id);
     }
 }

--- a/src/main/java/com/forjix/cuentoskilla/service/CuentoService.java
+++ b/src/main/java/com/forjix/cuentoskilla/service/CuentoService.java
@@ -1,0 +1,49 @@
+package com.forjix.cuentoskilla.service;
+
+import com.forjix.cuentoskilla.model.Cuento;
+import com.forjix.cuentoskilla.repository.CuentoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class CuentoService {
+    private final CuentoRepository repo;
+
+    public CuentoService(CuentoRepository repo) {
+        this.repo = repo;
+    }
+
+    public List<Cuento> findAll() {
+        return repo.findAll();
+    }
+
+    public Optional<Cuento> findById(Long id) {
+        return repo.findById(id);
+    }
+
+    public Cuento save(Cuento cuento) {
+        return repo.save(cuento);
+    }
+
+    public Optional<Cuento> update(Long id, Cuento cuento) {
+        return repo.findById(id)
+                .map(existing -> {
+                    cuento.setId(id);
+                    return repo.save(cuento);
+                });
+    }
+
+    public Optional<Cuento> updateEstado(Long id, Cuento cuento) {
+        return repo.findById(id)
+                .map(existing -> {
+                    existing.setHabilitado(cuento.isHabilitado());
+                    return repo.save(existing);
+                });
+    }
+
+    public void delete(Long id) {
+        repo.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `CuentoService` encapsulating repository operations
- delegate all `CuentoController` actions to new service layer

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896d8aa4cf48327914522096a76043a