### PR TITLE
Use enum for user roles

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/config/FirebaseTokenFilter.java
+++ b/src/main/java/com/forjix/cuentoskilla/config/FirebaseTokenFilter.java
@@ -29,9 +29,11 @@ public class FirebaseTokenFilter extends OncePerRequestFilter {
             try {
                 FirebaseToken decodedToken = FirebaseAuth.getInstance().verifyIdToken(idToken);
                 String uid = decodedToken.getUid();
-                String role = decodedToken.getClaims().getOrDefault("role", "USER").toString();
+                Rol role = Rol.valueOf(decodedToken.getClaims()
+                        .getOrDefault("role", Rol.USER.name()).toString());
 
-                List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+                List<SimpleGrantedAuthority> authorities =
+                        List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
                
 
                 UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/forjix/cuentoskilla/config/UserDetailsImpl.java
+++ b/src/main/java/com/forjix/cuentoskilla/config/UserDetailsImpl.java
@@ -22,7 +22,7 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole()));
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
     }
 
     @Override

--- a/src/main/java/com/forjix/cuentoskilla/controller/AuthController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.forjix.cuentoskilla.controller;
 import com.forjix.cuentoskilla.config.JwtUtil;
 import com.forjix.cuentoskilla.config.UserDetailsImpl;
 import com.forjix.cuentoskilla.model.User;
+import com.forjix.cuentoskilla.model.Rol;
 import com.forjix.cuentoskilla.model.DTOs.LoginResponse;
 import com.forjix.cuentoskilla.repository.UserRepository;
 import jakarta.validation.Valid;
@@ -37,7 +38,7 @@ public class AuthController {
     @PostMapping("/register")
     public User register(@Valid @RequestBody User user) {
         user.setPassword(passwordEncoder.encode(user.getPassword()));
-        user.setRole("USER");
+        user.setRole(Rol.USER);
         return userRepo.save(user);
     }
 

--- a/src/main/java/com/forjix/cuentoskilla/controller/OrderController.java
+++ b/src/main/java/com/forjix/cuentoskilla/controller/OrderController.java
@@ -64,7 +64,7 @@ public class OrderController {
         if (user == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-        if (servUser.findById(user.getId()).get().getRole().equals(Rol.ADMIN.toString())){
+        if (servUser.findById(user.getId()).get().getRole() == Rol.ADMIN){
             return ResponseEntity.ok(service.getOrders(user.getId()));
         }
         return ResponseEntity.ok(service.getOrdersByUser(user.getId()));

--- a/src/main/java/com/forjix/cuentoskilla/model/User.java
+++ b/src/main/java/com/forjix/cuentoskilla/model/User.java
@@ -25,7 +25,8 @@ public class User {
     private String telefono; // formato Perú: 9 dígitos
     private String documento; // DNI o RUC
 
-    private String role;
+    @Enumerated(EnumType.STRING)
+    private Rol role;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -98,11 +99,11 @@ public class User {
         this.documento = documento;
     }
 
-    public String getRole() {
+    public Rol getRole() {
         return role;
     }
 
-    public void setRole(String role) {
+    public void setRole(Rol role) {
         this.role = role;
     }
 

--- a/src/test/java/com/forjix/cuentoskilla/controller/PaymentVoucherControllerTest.java
+++ b/src/test/java/com/forjix/cuentoskilla/controller/PaymentVoucherControllerTest.java
@@ -6,6 +6,7 @@ import com.forjix.cuentoskilla.config.UserDetailsServiceImpl;
 import com.forjix.cuentoskilla.model.Order;
 import com.forjix.cuentoskilla.model.OrderStatus;
 import com.forjix.cuentoskilla.model.User;
+import com.forjix.cuentoskilla.model.Rol;
 import com.forjix.cuentoskilla.service.MercadoPagoService;
 import com.forjix.cuentoskilla.service.OrderService;
 import com.forjix.cuentoskilla.service.StorageService;
@@ -54,7 +55,7 @@ public class PaymentVoucherControllerTest {
         User mockUser = new User();
         mockUser.setId(1L);
         mockUser.setEmail("user@example.com");
-        mockUser.setRole("USER");
+        mockUser.setRole(Rol.USER);
         UserDetailsImpl userDetails = new UserDetailsImpl(mockUser);
 
         Order order = new Order();


### PR DESCRIPTION
## Summary
- store `User.role` as `Rol` enum instead of raw string
- adapt authentication, controllers, and tests to new enum-based role handling
- parse role claims as enum in Firebase token filter

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.forjix:cuentos-killa-backend:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_6896d8cab8f88327bde6ef2a144b2b33