### PR TITLE
Externalize JWT secret configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Defina la variable de entorno `SENTRY_DSN` con el DSN de su proyecto para habili
 Para que el plugin de Maven pueda subir el código fuente a Sentry debe
 establecer la variable `SENTRY_AUTH_TOKEN` con un token válido.
 Se utiliza `sentry-spring-boot-starter` 7.15.0 que es compatible con Spring Boot 3.3.
+
+## JWT
+
+La clave utilizada para firmar los tokens JWT se configura mediante la propiedad
+`jwt.secret`. En despliegues debe proporcionarse a través de la variable de
+entorno `JWT_SECRET` para mantenerla fuera del código fuente. Para desarrollo
+local se puede definir un valor por defecto en `application-local.yml`.

--- a/src/main/java/com/forjix/cuentoskilla/config/JwtUtil.java
+++ b/src/main/java/com/forjix/cuentoskilla/config/JwtUtil.java
@@ -2,6 +2,7 @@ package com.forjix.cuentoskilla.config;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
@@ -10,8 +11,12 @@ import java.util.Date;
 @Component
 public class JwtUtil {
 
-    private final String secret = "mi-clave-secreta-muy-larga-para-token-de-cuentos-killa-123456789"; // Debe ser de al menos 256 bits (32 chars)
+    private final String secret;
     private final long expiration = 1000 * 60 * 60 * 5; // 5 horas
+
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
+        this.secret = secret;
+    }
 
     private Key getSigningKey() {
         return Keys.hmacShaKeyFor(secret.getBytes());

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,3 +22,6 @@ mercadopago:
     failure: https://your-frontend.com/payment/failure
     pending: https://your-frontend.com/payment/pending
   notification-url: https://your-api-backend.com/api/webhooks/mercadopago
+
+jwt:
+  secret: ${JWT_SECRET:local-secret}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,3 +25,6 @@ mercadopago:
     failure: https://your-frontend.com/payment/failure
     pending: https://your-frontend.com/payment/pending
   notification-url: https://your-api-backend.com/api/webhooks/mercadopago
+
+jwt:
+  secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,9 @@ mercadopago:
     pending: https://your-frontend.com/payment/pending
   notification-url: https://your-api-backend.com/api/webhooks/mercadopago
 
+jwt:
+  secret: ${JWT_SECRET:change-me}
+
 sentry:
   dsn: ${SENTRY_DSN:}
   send-default-pii: true


### PR DESCRIPTION
## Summary
- Read JWT signing secret from `jwt.secret` property, injected via `@Value`.
- Add `jwt.secret` property to base, local, and production configuration, sourcing from `JWT_SECRET` env var.
- Document environment variable usage for JWT in README.

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6896d8dbe1a08327869aee0425551640