### PR TITLE
Remove duplicated documento accessors and add compilation-guard test

### DIFF
--- a/src/main/java/com/forjix/cuentoskilla/model/User.java
+++ b/src/main/java/com/forjix/cuentoskilla/model/User.java
@@ -120,22 +120,6 @@ public class User {
         this.documento = documento;
     }
 
-    public String getDocumentoTipo() {
-        return documentoTipo;
-    }
-
-    public void setDocumentoTipo(String documentoTipo) {
-        this.documentoTipo = documentoTipo;
-    }
-
-    public String getDocumentoNumero() {
-        return documentoNumero;
-    }
-
-    public void setDocumentoNumero(String documentoNumero) {
-        this.documentoNumero = documentoNumero;
-    }
-
     public Rol getRole() {
         return role;
     }

--- a/src/test/java/com/forjix/cuentoskilla/model/UserAccessorsCompilationGuardTest.java
+++ b/src/test/java/com/forjix/cuentoskilla/model/UserAccessorsCompilationGuardTest.java
@@ -1,0 +1,27 @@
+package com.forjix.cuentoskilla.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class UserAccessorsCompilationGuardTest {
+
+    @Test
+    void shouldExposeSingleDocumentoTipoAndDocumentoNumeroAccessors() {
+        assertEquals(1, countMethod(User.class, "getDocumentoTipo"));
+        assertEquals(1, countMethod(User.class, "setDocumentoTipo", String.class));
+        assertEquals(1, countMethod(User.class, "getDocumentoNumero"));
+        assertEquals(1, countMethod(User.class, "setDocumentoNumero", String.class));
+    }
+
+    private long countMethod(Class<?> type, String name, Class<?>... parameterTypes) {
+        Method[] methods = type.getDeclaredMethods();
+        return Arrays.stream(methods)
+                .filter(method -> method.getName().equals(name))
+                .filter(method -> Arrays.equals(method.getParameterTypes(), parameterTypes))
+                .count();
+    }
+}


### PR DESCRIPTION
### Motivation

- Eliminate duplicated accessor methods for `documentoTipo` and `documentoNumero` in the `User` model to avoid confusion and potential maintenance issues.
- Add a small compile-time guard test to prevent accidental reintroduction of duplicate accessors in future changes.

### Description

- Removed the duplicated `getDocumentoTipo`, `setDocumentoTipo`, `getDocumentoNumero`, and `setDocumentoNumero` method block from `src/main/java/com/forjix/cuentoskilla/model/User.java`.
- Added `src/test/java/com/forjix/cuentoskilla/model/UserAccessorsCompilationGuardTest.java` which asserts there is exactly one of each accessor method: `getDocumentoTipo`, `setDocumentoTipo(String)`, `getDocumentoNumero`, and `setDocumentoNumero(String)`.

### Testing

- Added unit test `UserAccessorsCompilationGuardTest` that inspects declared methods via reflection and enforces the expected accessor counts.
- Ran the test suite via `mvn test` and the test suite, including the new compilation-guard test, passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae3d9e51a48327acf6134c5baf996d)